### PR TITLE
feat: Implemented authorization service and /import endpoint tied on it

### DIFF
--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "Serverless authorization service using Typescript",
+  "scripts": {
+    "deploy": "sls deploy",
+    "offline": "sls offline"
+  },
+  "author": "Denis Shutikov",
+  "license": "MIT"
+}

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,24 @@
+service: authorization-service
+frameworkVersion: '2'
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: dev
+  region: eu-west-1
+
+custom:
+  webpack:
+    webpackConfig: '../webpack.config.js'
+    includeModules: true
+  serverless-offline:
+    httpPort: 4002
+
+plugins:
+  - 'serverless-webpack'
+  - 'serverless-offline'
+  - 'serverless-dotenv-plugin'
+
+functions:
+  basicAuthorizer:
+    handler: src/handlers/basicAuthorizer/basicAuthorizer.basicAuthorizer

--- a/authorization-service/src/handlers/basicAuthorizer/basicAuthorizer.ts
+++ b/authorization-service/src/handlers/basicAuthorizer/basicAuthorizer.ts
@@ -1,0 +1,41 @@
+import { APIGatewayTokenAuthorizerHandler, APIGatewayAuthorizerResult } from 'aws-lambda';
+
+const createResult = (principalId, Resource, Effect = 'Allow'): APIGatewayAuthorizerResult => ({
+  principalId,
+  policyDocument: {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Action: 'execute-api:Invoke',
+        Effect,
+        Resource
+      }
+    ]
+  }
+});
+
+export const basicAuthorizer: APIGatewayTokenAuthorizerHandler = async (event) => {
+  try {
+    console.log('event: ', JSON.stringify(event));
+
+    const [ tokenType, token ] = event.authorizationToken.split(' ');
+
+    if (tokenType !== 'Basic') {
+      console.log("tokenType isn't Basic");
+      return createResult(event.authorizationToken, event.methodArn, 'Deny');
+    }
+
+    const [ username, password ] = Buffer.from(token, 'base64').toString('utf-8').split(':');
+
+    console.log('username: ', username);
+    console.log('password: ', password);
+
+    const storedUserPassword = process.env[username];
+    const effect = !storedUserPassword || storedUserPassword !== password ? 'Deny': 'Allow';
+
+    return createResult(event.authorizationToken, event.methodArn, effect);
+  } catch (e) {
+    console.error(e.message);
+    return createResult(event.authorizationToken, event.methodArn, 'Deny');
+  }
+};

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -38,6 +38,7 @@ plugins:
   - 'serverless-webpack'
   - 'serverless-offline'
   - 'serverless-dotenv-plugin'
+  - 'serverless-pseudo-parameters'
 
 functions:
   importProductsFile:
@@ -51,6 +52,12 @@ functions:
             parameters:
               querystrings:
                 name: true
+          authorizer:
+            name: basicAuthorizer
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
+            type: token
+            arn: arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:authorization-service-dev-basicAuthorizer
   importFileParser:
     handler: src/handlers/importFileParser/importFileParser.importFileParser
     events:
@@ -93,3 +100,13 @@ resources:
               Resource: arn:aws:s3:::${self:custom.s3.bucket}/*
         Bucket:
           Ref: AwsCource
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Methods: "'GET,OPTIONS'"
+        ResponseType: DEFAULT_4XX
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2930,11 +2930,6 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
-    "@types/pg-format": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/pg-format/-/pg-format-1.0.1.tgz",
-      "integrity": "sha512-TC073gk+fvWGenuE7sDEjmt33HJkNhKJ9uLRgP9O9KQGSUaN1hA7Snbr63EU9/aE1X4Zz0+1BXhSBdZCYFWXog=="
-    },
     "@types/prettier": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
@@ -12229,11 +12224,6 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
       "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
     },
-    "pg-format": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
-      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4="
-    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -13829,6 +13819,12 @@
           }
         }
       }
+    },
+    "serverless-pseudo-parameters": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.5.0.tgz",
+      "integrity": "sha512-A/O49AR8LL6jlnPSmnOTYgL1KqVgskeRla4sVDeS/r5dHFJlwOU5MgFilc7aaQP8NWAwRJANaIS9oiSE3I+VUA==",
+      "dev": true
     },
     "serverless-webpack": {
       "version": "5.3.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "product:offline": "cd ./product-service && sls offline",
     "import:deploy": "cd ./import-service && sls deploy",
     "import:offline": "cd ./import-service && sls offline",
-    "all:deploy": "npm run product:deploy && npm run import:deploy",
+    "authorization:deploy": "cd ./authorization-service && sls deploy",
+    "all:deploy": "npm run authorization:deploy && npm run product:deploy && npm run import:deploy",
     "test": "jest --colors"
   },
   "dependencies": {
@@ -37,6 +38,7 @@
     "serverless": "^2.9.0",
     "serverless-dotenv-plugin": "^3.1.0",
     "serverless-offline": "^6.8.0",
+    "serverless-pseudo-parameters": "^2.5.0",
     "serverless-webpack": "^5.2.0",
     "ts-loader": "^5.3.3",
     "ts-node": "^8.10.2",


### PR DESCRIPTION
Main scope (covered):

- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

Additional scope (covered):

- [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file

Link to FE PR: https://github.com/Shutya/nodejs-aws-fe/pull/6

CloudFront URL: https://dkqjmtkbng0bb.cloudfront.net

Data in local storage: authorization_token = U2h1dHlhOlRFU1RfUEFTU1dPUkQ